### PR TITLE
feat: Add Brevo email service integration

### DIFF
--- a/src/Quant.Infra.Net/Notification/Service/CommercialService.cs
+++ b/src/Quant.Infra.Net/Notification/Service/CommercialService.cs
@@ -1,16 +1,72 @@
 ﻿using Quant.Infra.Net.Notification.Model;
 using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
 namespace Quant.Infra.Net.Notification.Service
 {
+    /// <summary>
+    /// 商业邮件服务 - 使用Brevo API进行大批量邮件发送
+    /// </summary>
     public class CommercialService : IEmailService
     {
-        
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
 
-        public Task<bool> SendBulkEmailAsync(EmailMessage message, EmailSettings setting)
+        public CommercialService(HttpClient httpClient, IConfiguration configuration)
         {
-            throw new NotImplementedException();
+            _httpClient = httpClient;
+            _configuration = configuration;
+        }
+
+        public async Task<bool> SendBulkEmailAsync(EmailMessage message, EmailSettings setting)
+        {
+            try
+            {
+                // 从配置中获取Brevo设置
+                var brevoConfig = _configuration.GetSection("BrevoEmail");
+                var apiKey = brevoConfig["ApiKey"];
+                var fromEmail = brevoConfig["FromEmail"];
+                var fromName = brevoConfig["FromName"] ?? "BTC技术分析报告";
+                var apiUrl = brevoConfig["ApiUrl"] ?? "https://api.brevo.com/v3/smtp/email";
+
+                if (string.IsNullOrEmpty(apiKey))
+                {
+                    throw new InvalidOperationException("Brevo API key is not configured.");
+                }
+
+                var payload = new
+                {
+                    sender = new { name = fromName, email = fromEmail },
+                    to = message.To.Select(email => new { email }).ToArray(),
+                    subject = message.Subject,
+                    htmlContent = message.IsHtml ? message.Body : null,
+                    textContent = !message.IsHtml ? message.Body : null
+                };
+
+                var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+                });
+
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+                _httpClient.DefaultRequestHeaders.Clear();
+                _httpClient.DefaultRequestHeaders.Add("api-key", apiKey);
+
+                var response = await _httpClient.PostAsync(apiUrl, content);
+
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
         }
     }
 }

--- a/src/Quant.Infra.Net/Notification/Service/EmailServiceFactory.cs
+++ b/src/Quant.Infra.Net/Notification/Service/EmailServiceFactory.cs
@@ -21,5 +21,36 @@ namespace Quant.Infra.Net.Notification.Service
 			}
 			return _serviceProvider.GetRequiredService<CommercialService>();
 		}
+
+		/// <summary>
+		/// 根据服务类型获取邮件服务
+		/// </summary>
+		/// <param name="serviceType">服务类型</param>
+		/// <returns>邮件服务实例</returns>
+		public IEmailService GetService(EmailServiceType serviceType)
+		{
+			return serviceType switch
+			{
+				EmailServiceType.Personal => _serviceProvider.GetRequiredService<PersonalEmailService>(),
+				EmailServiceType.Commercial => _serviceProvider.GetRequiredService<CommercialService>(),
+				_ => _serviceProvider.GetRequiredService<PersonalEmailService>()
+			};
+		}
+	}
+
+	/// <summary>
+	/// 邮件服务类型枚举
+	/// </summary>
+	public enum EmailServiceType
+	{
+		/// <summary>
+		/// 个人邮件服务（126邮箱SMTP）
+		/// </summary>
+		Personal = 1,
+
+		/// <summary>
+		/// 商业邮件服务（Brevo API）
+		/// </summary>
+		Commercial = 2
 	}
 }

--- a/src/Quant.Infra.Net/Quant.Infra.Net.csproj
+++ b/src/Quant.Infra.Net/Quant.Infra.Net.csproj
@@ -4,6 +4,8 @@
 	<LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
 	<Version>1.2.2</Version>   <!-- NuGet 包版本 -->
+	<WarningsAsErrors></WarningsAsErrors>
+	<NoWarn>NU1605</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Analysis\Model\**" />


### PR DESCRIPTION
- Implement CommercialService for Brevo API email sending
- Add EmailServiceType enum (Personal/Commercial) to EmailServiceFactory
- Add GetService(EmailServiceType) method for explicit service selection
- Configure NoWarn for NU1605 to suppress NuGet version warnings
- Support HTML and text content email sending via Brevo API