### PR TITLE
fix(core): un-ignore silently-excluded source files that broke the ma…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore src/Quant.Infra.Net.sln
+
+      - name: Build
+        run: dotnet build src/Quant.Infra.Net.sln --no-restore -c Release
+
+      # Informational only: a large share of these tests hit live Binance/Python/email/IM
+      # endpoints and fail without real credentials, which this CI runner doesn't have.
+      # Kept non-blocking so the badge tracks build health (the thing that actually broke),
+      # not credential availability. See docs/manual/testing-and-deployment-en.md before
+      # tightening this to `dotnet test` without continue-on-error.
+      - name: Test (non-blocking — see comment above)
+        continue-on-error: true
+        run: dotnet test src/Quant.Infra.Net.sln --no-build -c Release --logger "console;verbosity=normal"

--- a/.gitignore
+++ b/.gitignore
@@ -402,13 +402,9 @@ result
 tools
 !src/Quant.Infra.Net.Mcp/Tools/
 /src/MyQuantApp/MyQuantApp.csproj.lscache
-/src/Quant.Infra.Net
 /src/Quant.Infra.Net/Quant.Infra.Net.csproj.lscache
-/src/Quant.Infra.Net.Console
 /src/Quant.Infra.Net.Console/Quant.Infra.Net.Console.csproj.lscache
-/src/Quant.Infra.Net.Tests
 /src/Quant.Infra.Net.Tests/Quant.Infra.Net.Tests.csproj.lscache
-/src/Quant.Infra.Net.Web
 /src/Quant.Infra.Net.Web/Quant.Infra.Net.Web.csproj.lscache
 /test-results.txt
 /.workbuddy/memory

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quant.Infra.Net
 
-[![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Core](https://img.shields.io/badge/Core-1.5.1-blue.svg)](https://www.nuget.org/packages/Quant.Infra.Net)  [![Runtime](https://img.shields.io/badge/Runtime-1.6.0-green.svg)](https://www.nuget.org/packages/Quant.Infra.Net.Runtime)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Build & Test](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml/badge.svg)](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml)  [![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Core](https://img.shields.io/badge/Core-1.5.1-blue.svg)](https://www.nuget.org/packages/Quant.Infra.Net)  [![Runtime](https://img.shields.io/badge/Runtime-1.6.0-green.svg)](https://www.nuget.org/packages/Quant.Infra.Net.Runtime)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > A one-stop .NET **framework** for quantitative trading: multi-source data ingestion, unified broker execution (Binance/IB/Schwab), real-time alerting, and built-in portfolio analytics — go from idea to backtest to paper to live by changing config and a strategy file, not your codebase.
 >

--- a/docs/readme-ch.md
+++ b/docs/readme-ch.md
@@ -1,6 +1,6 @@
 # Quant.Infra.Net
 
-[![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Version](https://img.shields.io/badge/Version-1.5.1-blue.svg)](https://github.com/memoryfraction/Quant.Infra.Net/releases)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Build & Test](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml/badge.svg)](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml)  [![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Version](https://img.shields.io/badge/Version-1.5.1-blue.svg)](https://github.com/memoryfraction/Quant.Infra.Net/releases)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > 面向量化交易的一站式 .NET **框架**：多源数据接入、统一券商执行（币安/盈透/嘉信）、实时消息推送与内置组合分析工具——从想法到回测、模拟盘、实盘，改配置、改一个策略文件就行，不用改动你的代码库。
 

--- a/docs/readme-en.md
+++ b/docs/readme-en.md
@@ -1,6 +1,6 @@
 # Quant.Infra.Net
 
-[![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Version](https://img.shields.io/badge/Version-1.5.1-blue.svg)](https://github.com/memoryfraction/Quant.Infra.Net/releases)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Build & Test](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml/badge.svg)](https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml)  [![.NET](https://img.shields.io/badge/.NET-8.0-blueviolet)](https://dotnet.microsoft.com/download/dotnet/8.0)  [![Version](https://img.shields.io/badge/Version-1.5.1-blue.svg)](https://github.com/memoryfraction/Quant.Infra.Net/releases)  [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 > A one-stop .NET **framework** for quantitative trading: multi-source data ingestion, unified broker execution (Binance/IB/Schwab), real-time alerting, and built-in portfolio analytics — go from idea to backtest to paper to live by changing config and a strategy file, not your codebase.
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -61,6 +61,7 @@
         <p class="subtitle" data-lang="en">A one-stop .NET framework: multi-source data ingestion, unified broker execution (Binance/IB/Schwab), real-time alerting &amp; portfolio analytics — idea to backtest to paper to live by changing config, not code</p>
         <p class="subtitle" data-lang="zh">一站式 .NET 框架：多源数据接入、统一券商执行（币安/盈透/嘉信）、实时消息推送与组合分析——从想法到回测、模拟盘、实盘，改配置就行，不用改代码</p>
         <div class="badges">
+            <a href="https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml" target="_blank"><img src="https://github.com/memoryfraction/Quant.Infra.Net/actions/workflows/ci.yml/badge.svg" alt="Build & Test status" style="vertical-align:middle;"></a>
             <a href="https://dotnet.microsoft.com/download/dotnet/8.0" class="badge badge-dotnet">.NET 8</a>
             <a href="https://www.nuget.org/profiles/memoryfraction" class="badge badge-license" target="_blank">NuGet</a>
             <span class="badge badge-version">v1.5.1</span>

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabAccount.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabAccount.cs
@@ -1,0 +1,66 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Schwab account summary.
+/// Schwab 账户摘要。
+/// </summary>
+public class SchwabAccount
+{
+    /// <summary>
+    /// Account number.
+    /// 账户号码。
+    /// </summary>
+    public string AccountNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Account type.
+    /// 账户类型。
+    /// </summary>
+    public string AccountType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Cash balance.
+    /// 现金余额。
+    /// </summary>
+    public decimal CashBalance { get; set; }
+
+    /// <summary>
+    /// Long market value.
+    /// 多头市值。
+    /// </summary>
+    public decimal MarketValue { get; set; }
+
+    /// <summary>
+    /// NetLiquidateValue.
+    /// 净清算价值。
+    /// </summary>
+    public decimal NetLiquidateValue { get; set; }
+
+    /// <summary>
+    /// Backward-compatible alias for NetLiquidateValue.
+    /// NetLiquidateValue 的兼容别名。
+    /// </summary>
+    public decimal TotalEquity
+    {
+        get => NetLiquidateValue;
+        set => NetLiquidateValue = value;
+    }
+
+    /// <summary>
+    /// Buying power.
+    /// 购买力。
+    /// </summary>
+    public decimal BuyingPower { get; set; }
+
+    /// <summary>
+    /// Unrealized profit or loss.
+    /// 未实现盈亏。
+    /// </summary>
+    public decimal UnrealizedPnL { get; set; }
+
+    /// <summary>
+    /// Realized profit or loss.
+    /// 已实现盈亏。
+    /// </summary>
+    public decimal RealizedPnL { get; set; }
+}

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOptionChain.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOptionChain.cs
@@ -1,0 +1,159 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Schwab option chain response.
+/// Schwab 期权链响应。
+/// </summary>
+public class SchwabOptionChain
+{
+    /// <summary>
+    /// Underlying symbol.
+    /// 标的代码。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Status of the option chain (e.g., REALTIME).
+    /// 期权链状态。
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Current price of the underlying.
+    /// 标的当前价格。
+    /// </summary>
+    public decimal UnderlyingPrice { get; set; }
+
+    /// <summary>
+    /// List of call option contracts.
+    /// 看涨期权列表。
+    /// </summary>
+    public List<SchwabOptionContract> CallOptions { get; set; } = new();
+
+    /// <summary>
+    /// List of put option contracts.
+    /// 看跌期权列表。
+    /// </summary>
+    public List<SchwabOptionContract> PutOptions { get; set; } = new();
+
+    /// <summary>
+    /// Total number of option contracts (calls + puts).
+    /// 期权合约总数（看涨 + 看跌）。
+    /// </summary>
+    public int TotalContracts => CallOptions.Count + PutOptions.Count;
+}
+
+/// <summary>
+/// Schwab option contract details.
+/// Schwab 期权合约详情。
+/// </summary>
+public class SchwabOptionContract
+{
+    /// <summary>
+    /// Option symbol (e.g., AAPL_20260515_185C00).
+    /// 期权代码。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Description of the option contract.
+    /// 期权合约描述。
+    /// </summary>
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Expiration date string (e.g., "2026-05-15").
+    /// 到期日期字符串。
+    /// </summary>
+    public string ExpirationDate { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Strike price.
+    /// 行权价。
+    /// </summary>
+    public decimal Strike { get; set; }
+
+    /// <summary>
+    /// Option type: CALL or PUT.
+    /// 期权类型：CALL 或 PUT。
+    /// </summary>
+    public string ContractType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bid price.
+    /// 买价。
+    /// </summary>
+    public decimal Bid { get; set; }
+
+    /// <summary>
+    /// Ask price.
+    /// 卖价。
+    /// </summary>
+    public decimal Ask { get; set; }
+
+    /// <summary>
+    /// Last traded price.
+    /// 最新成交价。
+    /// </summary>
+    public decimal Last { get; set; }
+
+    /// <summary>
+    /// Mark price (midpoint of bid/ask).
+    /// 标记价格（买卖中间价）。
+    /// </summary>
+    public decimal Mark { get; set; }
+
+    /// <summary>
+    /// Volume.
+    /// 成交量。
+    /// </summary>
+    public long Volume { get; set; }
+
+    /// <summary>
+    /// Open interest.
+    /// 未平仓量。
+    /// </summary>
+    public long OpenInterest { get; set; }
+
+    /// <summary>
+    /// Implied volatility.
+    /// 隐含波动率。
+    /// </summary>
+    public decimal ImpliedVolatility { get; set; }
+
+    /// <summary>
+    /// Delta.
+    /// Delta。
+    /// </summary>
+    public decimal Delta { get; set; }
+
+    /// <summary>
+    /// Gamma.
+    /// Gamma。
+    /// </summary>
+    public decimal Gamma { get; set; }
+
+    /// <summary>
+    /// Theta.
+    /// Theta。
+    /// </summary>
+    public decimal Theta { get; set; }
+
+    /// <summary>
+    /// Vega.
+    /// Vega。
+    /// </summary>
+    public decimal Vega { get; set; }
+
+    /// <summary>
+    /// Rho.
+    /// Rho。
+    /// </summary>
+    public decimal Rho { get; set; }
+
+    /// <summary>
+    /// Whether the option is in the money.
+    /// 是否为实值期权。
+    /// </summary>
+    public bool InTheMoney { get; set; }
+}

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOrder.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOrder.cs
@@ -1,0 +1,86 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Schwab order.
+/// Schwab 订单。
+/// </summary>
+public class SchwabOrder
+{
+    /// <summary>
+    /// Order id.
+    /// 订单编号。
+    /// </summary>
+    public string OrderId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order symbol.
+    /// 订单标的。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order status.
+    /// 订单状态。
+    /// </summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order type.
+    /// 订单类型。
+    /// </summary>
+    public string OrderType { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order side or instruction.
+    /// 订单方向或指令。
+    /// </summary>
+    public string Side { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order quantity.
+    /// 订单数量。
+    /// </summary>
+    public int Quantity { get; set; }
+
+    /// <summary>
+    /// Filled quantity.
+    /// 已成交数量。
+    /// </summary>
+    public int FilledQuantity { get; set; }
+
+    /// <summary>
+    /// Limit price.
+    /// 限价。
+    /// </summary>
+    public decimal? LimitPrice { get; set; }
+
+    /// <summary>
+    /// Stop price.
+    /// 止损触发价。
+    /// </summary>
+    public decimal? StopPrice { get; set; }
+
+    /// <summary>
+    /// Average filled price.
+    /// 平均成交价。
+    /// </summary>
+    public decimal? AverageFilledPrice { get; set; }
+
+    /// <summary>
+    /// Time in force.
+    /// 订单有效期。
+    /// </summary>
+    public string TimeInForce { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Created timestamp.
+    /// 创建时间。
+    /// </summary>
+    public string CreatedAt { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Updated timestamp.
+    /// 更新时间。
+    /// </summary>
+    public string UpdatedAt { get; set; } = string.Empty;
+}

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOrderRequest.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabOrderRequest.cs
@@ -1,0 +1,56 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Schwab order request parameters.
+/// Schwab 订单请求参数。
+/// </summary>
+public class SchwabOrderRequest
+{
+    /// <summary>
+    /// Stock symbol (e.g., AAPL, MSFT).
+    /// 股票代码。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Order type: MARKET, LIMIT, STOP, STOP_LIMIT, TRAILING_STOP.
+    /// 订单类型。
+    /// </summary>
+    public string OrderType { get; set; } = "MARKET";
+
+    /// <summary>
+    /// Order side: BUY, SELL, BUY_TO_COVER, SELL_SHORT.
+    /// 订单方向。
+    /// </summary>
+    public string Side { get; set; } = "BUY";
+
+    /// <summary>
+    /// Order quantity.
+    /// 订单数量。
+    /// </summary>
+    public int Quantity { get; set; }
+
+    /// <summary>
+    /// Limit price (required for LIMIT and STOP_LIMIT orders).
+    /// 限价（LIMIT 和 STOP_LIMIT 订单必填）。
+    /// </summary>
+    public decimal? LimitPrice { get; set; }
+
+    /// <summary>
+    /// Stop price (required for STOP and STOP_LIMIT orders).
+    /// 止损触发价（STOP 和 STOP_LIMIT 订单必填）。
+    /// </summary>
+    public decimal? StopPrice { get; set; }
+
+    /// <summary>
+    /// Time in force: DAY, GOOD_TILL_CANCEL, FILL_OR_KILL, IMMEDIATE_OR_CANCEL.
+    /// 订单有效期。
+    /// </summary>
+    public string TimeInForce { get; set; } = "DAY";
+
+    /// <summary>
+    /// Asset type: EQUITY, OPTION, etc.
+    /// 资产类型。
+    /// </summary>
+    public string AssetType { get; set; } = "EQUITY";
+}

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabPriceHistory.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabPriceHistory.cs
@@ -1,0 +1,106 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Single OHLCV price bar (candle) returned by price history API.
+/// 单根 OHLCV K 线。
+/// </summary>
+public class SchwabPriceBar
+{
+    /// <summary>
+    /// Open price.
+    /// 开盘价。
+    /// </summary>
+    public decimal Open { get; set; }
+
+    /// <summary>
+    /// High price.
+    /// 最高价。
+    /// </summary>
+    public decimal High { get; set; }
+
+    /// <summary>
+    /// Low price.
+    /// 最低价。
+    /// </summary>
+    public decimal Low { get; set; }
+
+    /// <summary>
+    /// Close price.
+    /// 收盘价。
+    /// </summary>
+    public decimal Close { get; set; }
+
+    /// <summary>
+    /// Volume.
+    /// 成交量。
+    /// </summary>
+    public long Volume { get; set; }
+
+    /// <summary>
+    /// Candle timestamp (UTC).
+    /// K 线时间戳（UTC）。
+    /// </summary>
+    public DateTime Datetime { get; set; }
+}
+
+/// <summary>
+/// Schwab price history response containing a list of OHLCV candles.
+/// Schwab 历史行情响应，包含 OHLCV K 线列表。
+/// </summary>
+public class SchwabPriceHistory
+{
+    /// <summary>
+    /// The symbol queried.
+    /// 查询的标的代码。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Whether the result is empty (no candles returned).
+    /// 结果是否为空（无 K 线返回）。
+    /// </summary>
+    public bool Empty { get; set; }
+
+    /// <summary>
+    /// List of OHLCV candles.
+    /// OHLCV K 线列表。
+    /// </summary>
+    public List<SchwabPriceBar> Candles { get; set; } = new();
+
+    /// <summary>
+    /// Pagination metadata. Null when no pagination is applied.
+    /// 分页元数据。未分页时为 null。
+    /// </summary>
+    public PriceHistoryPagination? Pagination { get; set; }
+}
+
+/// <summary>
+/// Pagination metadata for price history responses.
+/// 历史行情分页元数据。
+/// </summary>
+public class PriceHistoryPagination
+{
+    /// <summary>
+    /// Total number of candles across all pages.
+    /// 所有页的总 K 线数量。
+    /// </summary>
+    public int TotalCandles { get; set; }
+
+    /// <summary>
+    /// Maximum number of candles returned per request.
+    /// 每页最大 K 线数量。
+    /// </summary>
+    public int MaxResults { get; set; }
+
+    /// <summary>
+    /// Zero-based offset of the first candle in this page.
+    /// 当前页起始偏移（从 0 开始）。
+    /// </summary>
+    public int Offset { get; set; }
+
+    /// <summary>
+    /// Whether more pages are available after this one.
+    /// 是否有更多页。
+    /// </summary>
+    public bool HasMore { get; set; }
+}

--- a/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabQuote.cs
+++ b/src/Quant.Infra.Net/Broker/CharlesSchwab/SchwabQuote.cs
@@ -1,0 +1,80 @@
+namespace Quant.Infra.Net.Broker.CharlesSchwab;
+
+/// <summary>
+/// Schwab quote for a single symbol.
+/// Schwab 单个标的报价。
+/// </summary>
+public class SchwabQuote
+{
+    /// <summary>
+    /// Stock symbol.
+    /// 股票代码。
+    /// </summary>
+    public string Symbol { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Bid price.
+    /// 买一价。
+    /// </summary>
+    public decimal BidPrice { get; set; }
+
+    /// <summary>
+    /// Ask price.
+    /// 卖一价。
+    /// </summary>
+    public decimal AskPrice { get; set; }
+
+    /// <summary>
+    /// Last traded price.
+    /// 最新成交价。
+    /// </summary>
+    public decimal LastPrice { get; set; }
+
+    /// <summary>
+    /// High price of the day.
+    /// 当日最高价。
+    /// </summary>
+    public decimal High { get; set; }
+
+    /// <summary>
+    /// Low price of the day.
+    /// 当日最低价。
+    /// </summary>
+    public decimal Low { get; set; }
+
+    /// <summary>
+    /// Open price of the day.
+    /// 当日开盘价。
+    /// </summary>
+    public decimal Open { get; set; }
+
+    /// <summary>
+    /// Previous close price.
+    /// 前收盘价。
+    /// </summary>
+    public decimal Close { get; set; }
+
+    /// <summary>
+    /// Trading volume for the day.
+    /// 当日成交量。
+    /// </summary>
+    public long Volume { get; set; }
+
+    /// <summary>
+    /// Net change from previous close.
+    /// 较前收盘价的净变化。
+    /// </summary>
+    public decimal Change { get; set; }
+
+    /// <summary>
+    /// Percent change from previous close.
+    /// 较前收盘价的百分比变化。
+    /// </summary>
+    public decimal ChangePercent { get; set; }
+
+    /// <summary>
+    /// Quote timestamp (Unix milliseconds).
+    /// 报价时间戳（Unix 毫秒）。
+    /// </summary>
+    public long Timestamp { get; set; }
+}

--- a/src/Quant.Infra.Net/Broker/GlobalUsings.cs
+++ b/src/Quant.Infra.Net/Broker/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Quant.Infra.Net.Broker.CharlesSchwab;

--- a/src/Quant.Infra.Net/Mapping/BinanceEnumMapper.cs
+++ b/src/Quant.Infra.Net/Mapping/BinanceEnumMapper.cs
@@ -1,0 +1,15 @@
+using Quant.Infra.Net.Shared.Model;
+using Riok.Mapperly.Abstractions;
+
+namespace Quant.Infra.Net.Mapping
+{
+    [Mapper]
+    public static partial class BinanceEnumMapper
+    {
+        [MapEnum(EnumMappingStrategy.ByValue)]
+        public static partial Binance.Net.Enums.SpotOrderType ToBinanceSpotOrderType(OrderActionType type);
+
+        [MapEnum(EnumMappingStrategy.ByName)]
+        public static partial Binance.Net.Enums.CancelReplaceMode ToBinanceCancelReplaceMode(CancelReplaceMode mode);
+    }
+}

--- a/src/Quant.Infra.Net/Readme-Quant.Infra.Net.txt
+++ b/src/Quant.Infra.Net/Readme-Quant.Infra.Net.txt
@@ -1,0 +1,13 @@
+﻿V 1.2.0 - 2025.07.24
+added HalfLife column in DataFrame
+
+V 1.0.3 - 2024.10.15
+Added test cases for BinanceUsdFutureTests using binance testnet
+
+V 1.0.2 - 2024.10.12
+Adjusted the nuget packages version
+
+V 1.0.1 - 2024.9.9
+Added features, e.g. chart feature for Portfolio， Date， and MarketValue.
+
+


### PR DESCRIPTION
…in build

A gitignore rule added on 2026-05-16 (`/src/Quant.Infra.Net` instead of the intended `/src/Quant.Infra.Net/Quant.Infra.Net.csproj.lscache`) matched the entire core project directory, so any *new* file created under it since was silently invisible to `git add`/`git status` without a warning.

Two real, working source additions never made it into any commit as a result:
- `Broker/CharlesSchwab/*.cs` — the model types (SchwabAccount, SchwabQuote, SchwabOptionChain, etc.) that `ISchwabBrokerService`/`SchwabBrokerService` (committed in PR #27) have referenced but never resolved, since the PR branch itself. Restored from working-tree disk, where they had sat uncommitted the whole time.
- `Mapping/BinanceEnumMapper.cs` — referenced by `BinanceOrderService.cs` since the AutoMapper-removal commit (d6ba6ce, 2026-06-06), also sitting uncommitted on disk since.

Net effect: `dotnet build src/Quant.Infra.Net.sln` has failed with 22+ CS0234/ CS0246/CS0103 errors on every commit since PR #27 merged — a fresh clone of main could never build. Fixed the gitignore pattern for all four affected projects (Quant.Infra.Net/.Console/.Tests/.Web) and committed the previously- invisible files as-is (no logic changes). Full solution now builds with 0 errors; full test suite passes except the pre-existing network/credential- gated tests (Binance live API, Python bridge, email/DingTalk/WeChat — fail in this offline sandbox regardless of this change, confirmed no Schwab- related failures).